### PR TITLE
CMR-5271: As a data provider, I want OUS to use the OPeNDAP URL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.1.2-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.1.3-SNAPSHOT"
   :description ~(str "A library that provides convenience functions for "
                      "accessing and locally caching CMR metadata (granules, "
                      "collections, variables, services, etc.)")

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
        ns
        "\u001B[35m]\u001B[33m λ\u001B[m=> "))
 
-(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.1.3-SNAPSHOT"
+(defproject gov.nasa.earthdata/cmr-metadata-proxy "0.2.0-SNAPSHOT"
   :description ~(str "A library that provides convenience functions for "
                      "accessing and locally caching CMR metadata (granules, "
                      "collections, variables, services, etc.)")
@@ -29,11 +29,11 @@
     [clojusc/twig "0.4.0"]
     [com.stuartsierra/component "0.3.2"]
     [environ "1.1.0"]
-    [gov.nasa.earthdata/cmr-authz "0.1.1-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-exchange-common "0.2.1-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-exchange-query "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.5-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-mission-control "0.1.0-SNAPSHOT"]
+    [gov.nasa.earthdata/cmr-authz "0.1.1"]
+    [gov.nasa.earthdata/cmr-exchange-common "0.2.2"]
+    [gov.nasa.earthdata/cmr-exchange-query "0.2.0"]
+    [gov.nasa.earthdata/cmr-http-kit "0.1.5"]
+    [gov.nasa.earthdata/cmr-mission-control "0.1.0"]
     [metosin/ring-http-response "0.9.1"]
     [org.clojure/clojure "1.9.0"]
     [org.clojure/core.async "0.4.474"]
@@ -67,7 +67,7 @@
         [commons-io "2.6"]]}
     :system {
       :dependencies [
-        [clojusc/system-manager "0.3.0-SNAPSHOT"]]}
+        [clojusc/system-manager "0.3.0"]]}
     :local {
       :dependencies [
         [org.clojure/tools.namespace "0.2.11"]

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
     [gov.nasa.earthdata/cmr-exchange-query "0.2.0-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-http-kit "0.1.5-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-mission-control "0.1.0-SNAPSHOT"]
-    [metosin/ring-http-response "0.9.0"]
+    [metosin/ring-http-response "0.9.1"]
     [org.clojure/clojure "1.9.0"]
     [org.clojure/core.async "0.4.474"]
     [org.clojure/core.cache "0.7.1"]]
@@ -48,7 +48,7 @@
       :source-paths ["test"]}
     :security {
       :plugins [
-        [lein-nvd "0.5.5"]]
+        [lein-nvd "0.5.6"]]
       :source-paths ^:replace ["src"]
       :nvd {
         :suppression-file "resources/security/false-positives.xml"}
@@ -179,4 +179,3 @@
       ["clean"]
       ["build-jar"]
       ["deploy" "clojars"]]})
-

--- a/src/cmr/metadata/proxy/concepts/granule.clj
+++ b/src/cmr/metadata/proxy/concepts/granule.clj
@@ -111,7 +111,7 @@
     (and (not (:inherited link-data))
          (= const/datafile-link-rel rel))))
 
-(def OPENDAP_LOWERCASE
+(def opendap-lowercase
   "All lowercase OPeNDAP."
   "opendap")
 
@@ -125,7 +125,7 @@
   (let [lower-case-title (some-> link-data :title string/lower-case)]
     (and (not (:inherited link-data))
          lower-case-title
-         (string/includes? lower-case-title OPENDAP_LOWERCASE))))
+         (string/includes? lower-case-title opendap-lowercase))))
 
 (defn extract-granule-links
   "Returns an OPeNDAP link and a data download link from the granule metadata file.

--- a/src/cmr/metadata/proxy/concepts/granule.clj
+++ b/src/cmr/metadata/proxy/concepts/granule.clj
@@ -99,7 +99,6 @@
   (let [promise (async-get-metadata component search-endpoint user-token params)]
     (extract-metadata promise)))
 
-;; XXX The following may need to change once CMR-4912 is addressed ...
 (defn match-datafile-link
   "The criteria defined in the prototype was to iterate through the links,
   only examining those links that were not 'inherited', and find the one
@@ -112,17 +111,39 @@
     (and (not (:inherited link-data))
          (= const/datafile-link-rel rel))))
 
-(defn extract-datafile-link
+(def OPENDAP_LOWERCASE
+  "All lowercase OPeNDAP."
+  "opendap")
+
+(defn match-opendap-link
+  "The matching performed is trying to find the case insensitive string opendap
+  anywhere in the title for the URL. Until metadata is standardized for
+  specifying OPeNDAP links (and all providers have updated their metadata we'll
+  have to use this imprecise check)."
+  [link-data]
+  (log/trace "Link data:" link-data)
+  (let [lower-case-title (some-> link-data :title string/lower-case)]
+    (and (not (:inherited link-data))
+         lower-case-title
+         (string/includes? lower-case-title OPENDAP_LOWERCASE))))
+
+(defn extract-granule-links
+  "Returns an OPeNDAP link and a data download link from the granule metadata file.
+  We return the first link of each type from the granule entry if there are
+  multiple matches."
   [granule-entry]
   (log/trace "Granule entry: " granule-entry)
-  (let [link (->> (:links granule-entry)
-                  (filter match-datafile-link)
-                  first)
+  (let [opendap-link (->> (:links granule-entry)
+                          (filter match-opendap-link)
+                          first)
+        datafile-link (->> (:links granule-entry)
+                           (filter match-datafile-link)
+                           first)
         gran-id (:id granule-entry)]
-    (if link
+    (if (or opendap-link datafile-link)
       {:granule-id gran-id
-       :link-rel (:rel link)
-       :link-href (:href link)}
-      {:errors [metadata-errors/empty-gnl-data-file-url
+       :opendap-link opendap-link
+       :datafile-link datafile-link}
+      {:errors [metadata-errors/empty-granule-links
                 (when gran-id
                   (format metadata-errors/problem-granules gran-id))]})))

--- a/src/cmr/metadata/proxy/results/errors.clj
+++ b/src/cmr/metadata/proxy/results/errors.clj
@@ -13,8 +13,12 @@
        "values for the pattern fields?"))
 
 (def empty-gnl-data-file-url
-  (str "There was a problem extracting a data URL from the granule's service "
-       "data file."))
+  (str "There was a problem extracting a data URL from the granule's "
+       "metadata file."))
+
+(def empty-granule-links
+  (str "There was a problem extracting an OPeNDAP URL or data URL from the "
+       "granule's metadata file."))
 
 (def empty-gnl-data-files
   "There was a problem extracting a service data file from the granule.")

--- a/test/cmr/metadata/proxy/tests/unit/concepts/granule.clj
+++ b/test/cmr/metadata/proxy/tests/unit/concepts/granule.clj
@@ -1,0 +1,142 @@
+(ns cmr.metadata.proxy.tests.unit.concepts.granule
+  "Unit tests for the granule concepts."
+  (:require
+   [clojure.test :refer :all]
+   [cmr.metadata.proxy.concepts.granule :as granule]))
+
+(def sample-granule-entry
+  "Sample granule entry used in the tests."
+  {:producer_granule_id "MOD13Q1.A2000049.h23v09.006.2015136104649.hdf",
+   :time_start "2000-02-18T00:00:00.000Z",
+   :cloud_cover "79.0",
+   :updated "2017-01-23T14:11:51.777Z",
+   :dataset_id "MODIS/Terra Vegetation Indices 16-Day L3 Global 250m SIN Grid V006",
+   :data_center "DEMO_PROV",
+   :title "SC:MOD13Q1.006:2160434507",
+   :coordinate_system "GEODETIC",
+   :day_night_flag "DAY",
+   :time_end "2000-03-04T23:59:59.000Z",
+   :id "G1200241220-DEMO_PROV",
+   :original_format "ECHO10",
+   :granule_size "5.10831",
+   :browse_flag true,
+   :polygons [["-9.9999025 60.9317071 0.0053588 60.013813 -0.0001006 49.8129527 -10.004658 50.5752222 -9.9999025 60.9317071"]],
+   :collection_concept_id "C1200241219-DEMO_PROV",
+   :online_access_flag true,
+   :links [{:rel "http://esipfed.org/ns/fedsearch/1.1/data#",
+            :type "application/x-hdfeos",
+            :hreflang "en-US",
+            :href "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            :type "application/x-hdfeos",
+            :hreflang "en-US",
+            :title "(GET DATA : OPENDAP DATA (DODS))",
+            :href "https://opendap.cr.usgs.gov/opendap/hyrax//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            :type "image/jpeg",
+            :hreflang "en-US",
+            :title "(BROWSE)",
+            :href "https://e4ftl01.cr.usgs.gov//WORKING/BRWS/Browse.001/2015.05.16/BROWSE.MOD13Q1.A2000049.h23v09.006.2015136104649.1.jpg"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            :type "image/jpeg",
+            :hreflang "en-US",
+            :title "(BROWSE)",
+            :href "https://e4ftl01.cr.usgs.gov//WORKING/BRWS/Browse.001/2015.05.16/BROWSE.MOD13Q1.A2000049.h23v09.006.2015136104649.2.jpg"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            :type "text/xml",
+            :hreflang "en-US",
+            :title "(METADATA)",
+            :href "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf.xml"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            :hreflang "en-US",
+            :inherited true,
+            :href "https://dx.doi.org/10.5067/MODIS/MOD13Q1.006"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/data#",
+            :hreflang "en-US",
+            :inherited true,
+            :href "https://e4ftl01.cr.usgs.gov/MOLT/MOD13Q1.006/"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/data#",
+            :hreflang "en-US",
+            :inherited true,
+            :href "http://earthexplorer.usgs.gov/"}
+           {:rel "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            :hreflang "en-US",
+            :inherited true,
+            :href "https://lpdaac.usgs.gov/"}]})
+
+(deftest extract-granule-links
+  (testing "Both OPeNDAP and data file links."
+    (let [expected {:granule-id "G1200241220-DEMO_PROV"
+                    :opendap-link {:rel "http://esipfed.org/ns/fedsearch/1.1/metadata#"
+                                   :type "application/x-hdfeos"
+                                   :hreflang "en-US"
+                                   :title "(GET DATA : OPENDAP DATA (DODS))"
+                                   :href "https://opendap.cr.usgs.gov/opendap/hyrax//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}
+                    :datafile-link {:rel "http://esipfed.org/ns/fedsearch/1.1/data#"
+                                    :type "application/x-hdfeos"
+                                    :hreflang "en-US"
+                                    :href "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}}
+          actual (granule/extract-granule-links sample-granule-entry)]
+      (is (= expected actual))))
+  (testing "Only an OPeNDAP link."
+    (let [granule-entry (update sample-granule-entry
+                                :links
+                                (fn [links]
+                                  (remove #(= "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"
+                                              (:href %))
+                                          links)))
+          expected {:granule-id "G1200241220-DEMO_PROV"
+                    :opendap-link {:rel "http://esipfed.org/ns/fedsearch/1.1/metadata#"
+                                   :type "application/x-hdfeos"
+                                   :hreflang "en-US"
+                                   :title "(GET DATA : OPENDAP DATA (DODS))"
+                                   :href "https://opendap.cr.usgs.gov/opendap/hyrax//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}
+                    :datafile-link nil}
+          actual (granule/extract-granule-links granule-entry)]
+      (is (= expected actual))))
+  (testing "Only a data file link."
+    (let [granule-entry (update sample-granule-entry
+                                :links
+                                (fn [links]
+                                  (remove #(= "(GET DATA : OPENDAP DATA (DODS))"
+                                              (:title %))
+                                          links)))
+          expected {:granule-id "G1200241220-DEMO_PROV"
+                    :opendap-link nil
+                    :datafile-link {:rel "http://esipfed.org/ns/fedsearch/1.1/data#"
+                                    :type "application/x-hdfeos"
+                                    :hreflang "en-US"
+                                    :href "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}}
+          actual (granule/extract-granule-links granule-entry)]
+      (is (= expected actual))))
+  (testing "Multiple OPeNDAP links returns only the first one."
+    (let [granule-entry (update sample-granule-entry
+                                :links
+                                (fn [links]
+                                  (cons {:title "Another OPENDAP link."
+                                         :href "https://example.com/opendap-link"}
+                                        links)))
+          expected {:granule-id "G1200241220-DEMO_PROV"
+                    :opendap-link {:title "Another OPENDAP link."
+                                   :href "https://example.com/opendap-link"}
+                    :datafile-link {:rel "http://esipfed.org/ns/fedsearch/1.1/data#"
+                                    :type "application/x-hdfeos"
+                                    :hreflang "en-US"
+                                    :href "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"}}
+          actual (granule/extract-granule-links granule-entry)]
+      (is (= expected actual))))
+  (testing "No data file or opendap links."
+    (let [granule-entry (update sample-granule-entry
+                                :links
+                                (fn [links]
+                                  (remove (fn [link]
+                                            (or (= "(GET DATA : OPENDAP DATA (DODS))"
+                                                   (:title link))
+                                                (= "https://e4ftl01.cr.usgs.gov//DP106/MOLT/MOD13Q1.006/2000.02.18/MOD13Q1.A2000049.h23v09.006.2015136104649.hdf"
+                                                   (:href link))))
+                                          links)))
+          expected {:errors ["There was a problem extracting an OPeNDAP URL or data URL from the granule's metadata file."
+                             "Problematic granules: [G1200241220-DEMO_PROV]."]}
+          ; expected {:errors ["There was a problem extracting an OPeNDAP URL or data URL from the granule's metadata file."]}
+          actual (granule/extract-granule-links granule-entry)]
+      (is (= expected actual)))))


### PR DESCRIPTION
… from my Online Resources as the base OPeNDAP URL. Change to include both a datafile-link and an opendap-link when retrieving granule links.